### PR TITLE
Add releasever update to automation

### DIFF
--- a/hcp/tasks/hcp-create.yml
+++ b/hcp/tasks/hcp-create.yml
@@ -19,19 +19,31 @@
   register: hc
   changed_when: hc.resources |length > 0
     
+# If version is set to default, use the version from the hostingcluster for the hostedcluster
+- name: "deploy | set hostedcluster version"
+  ansible.builtin.shell:
+    oc get clusterversion -o jsonpath='{.items[*].spec.desiredUpdate.version}'
+  args:
+    executable: "{{lookup('ansible.builtin.env', 'SHELL')}}"
+  register: version
+  when: image == "default"
+
 # Create the hypershift cluster when create = true, the hc resource above is not changed and when destroy=false
 # Removed: --additional-tags {{ tags }}
 - name: "deploy | create cluster {{ name }}"
   ansible.builtin.shell: >
     hcp create cluster aws 
     --name {{ name }} 
+    --multi-arch={{ multiarch }}
     --node-pool-replicas {{ replicas }} 
     --instance-type {{ instance_type }} 
     --infra-id {{ name }} 
     --base-domain {{ domain }} 
     --pull-secret {{ pull_secret_path }} 
     --region {{ region }} 
-    {% if image != "latest" %}
+    {% if image == "default" %}
+    --release-image quay.io/openshift-release-dev/ocp-release:{{ version.stdout }}-x86_64
+    {% else %}
     --release-image quay.io/openshift-release-dev/ocp-release:{{ image }}-x86_64
     {% endif %}
     --sts-creds {{ sts_creds.dir }}/{{ sts_creds.file }}
@@ -52,10 +64,10 @@
       instance-type: {{ instance_type }}
       base-domain: {{ domain }}
       region: {{ region }}
-      {% if image != "latest" %}
+      {% if image != "default" %}
       ocp_version: {{ image }}"
       {% else %}
-      ocp_version: latest"
+      ocp_version: {{ version }}"
       {%endif %}      
 # Check for the nodepool resources - this takes the longest bc of the machines spinning up
 - name: "deploy | wait for nodepool provisioning to complete | this can take a while"

--- a/vars.yml
+++ b/vars.yml
@@ -13,5 +13,6 @@ region: changeme_region
 #Cluster Characteristics - Describe how you want the cluster deployed
 replicas: 1
 instance_type: m5.xlarge
-#Set to latest if you want to use the most recent release, otherwise define version: x.y.z (4.15.29) 
-image: latest
+#Setting to default uses the hosting-clusters version for the release-image. To deploy with a specific
+#version, define it below: x.y.z (4.15.29) 
+image: default


### PR DESCRIPTION
- Added task that looks up the clusterversion from the hosting cluster and uses that as the default for the hostedcluster. This allows us to have a way to deploy a cluster without requiring users to add a specific version to the vars.